### PR TITLE
Fixing Issue : raise TypeError('Internal error: quality type is...

### DIFF
--- a/src/phub/utils.py
+++ b/src/phub/utils.py
@@ -339,8 +339,8 @@ class Quality:
         if isinstance(self.value, str):
             # Get approximative quality
             
-            if self.value == Quality.BEST.value: return quals[max(keys)]
-            elif self.value == Quality.WORST.value: return quals[min(keys)]
+            if self.value == Quality.BEST: return quals[max(keys)]
+            elif self.value == Quality.WORST: return quals[min(keys)]
             else: return quals[ sorted(keys)[ len(keys) // 2 ] ]
         
         elif isinstance(self.value, int):
@@ -351,11 +351,5 @@ class Quality:
         
         # This should not happen
         raise TypeError('Internal error: quality type is', type(self.value))
-
-
-# Define presets as objects
-Quality.BEST = Quality(Quality.BEST)
-Quality.MIDDLE = Quality(Quality.MIDDLE)
-Quality.WORST = Quality(Quality.WORST)
 
 # EOF


### PR DESCRIPTION
Hi,

When I tried to download a video with a simple script like this:

from phub import Client, Quality
url = "https://de.pornhub.com/view_video.php?viewkey=64c73f8307b2a"
client = Client(language="en")
video = client.get(url)
video.download(quality=Quality.WORST, path="./")



I got this error: 

raise TypeError('Internal error: quality type is', type(self.value))
TypeError: ('Internal error: quality type is', <class 'phub.utils.Quality'>)

When I looked into the utils.py PyCharm told me, that the .new value is not defined, so I removed it.
Issue was not fixed, but after removing the presets further down it was. I don't know why, and I don't know if this is a good and stable solution or if it breaks anything, but I hope I could helped with it.

At least the video was downloaded successfully with this changes.




