### PR TITLE
progress callback for ffmpeg threading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.28.1
 click>=8.0.4
+ffmpeg-progress-yield

--- a/src/phub/modules/download.py
+++ b/src/phub/modules/download.py
@@ -71,7 +71,7 @@ def default(video: Video,
     with open(path, 'wb') as file:
         file.write(buffer)
     
-    logger.info('Downloading successfull.')
+    logger.info('Downloading successful.')
 
 def FFMPEG(video: Video,
            quality: Quality,
@@ -103,11 +103,17 @@ def FFMPEG(video: Video,
     logger.info('Executing `%s`', ' '.join(command))
 
     # Initialize FfmpegProgress and execute the command
-    ff = FfmpegProgress(command)
-    for progress in ff.run_command_with_progress():
-        # Update the callback with the current progress
-        print(progress)
-        callback(progress, 100)
+    try:
+        ff = FfmpegProgress(command)
+        for progress in ff.run_command_with_progress():
+            # Update the callback with the current progress
+            callback(progress, 100)
+
+            if progress == 100:
+                logger.info("Download successful")
+
+    except Exception as err:
+        logger.error('Error while downloading: %s', err)
 
 
 def _thread(client: Client, url: str, timeout: int) -> bytes:
@@ -116,6 +122,7 @@ def _thread(client: Client, url: str, timeout: int) -> bytes:
     '''
     
     return client.call(url, timeout = timeout).content
+
 
 def _base_threaded(client: Client,
                    segments: list[str],


### PR DESCRIPTION
Hi,

I've seen that your ffmpeg class doesn't provive callback. It's a bit hard to get real-time progress to work with ffmpeg, but smeone wrote a library for it [here](https://github.com/slhck/ffmpeg-progress-yield)

I addeed the functionality for this library to your FFMPEG preset. I didn't change any of the constants, so it shouldn't break any other classes or functions. I tested with multiple videos.

You can intall the library by using `pip install ffmpeg-progress-yield`

Here's the code example I used for testing:

```python
progress_bar = None


def callback(current, total):
    global progress_bar
    if progress_bar is None:
        progress_bar = tqdm(total=total)

    progress_bar.n = current
    print(current)
    progress_bar.refresh()
    sys.stdout.flush()
    if current == total:
        progress_bar.close()
        progress_bar = None


client = Client()
video = client.get(url)

video.download(path="./", quality="best", display=callback, downloader=FFMPEG)
```


I hope I can help you with that :) 
