### PR TITLE
Resolves issue#84

### DIFF
--- a/src/phub/__main__.py
+++ b/src/phub/__main__.py
@@ -50,6 +50,8 @@ def download_video(video, quality: Union[str, int], output: str, no_title: bool 
     if not no_title:
         output = os.path.join(output, title + ".mp4")
 
+    if output == './':
+        output = os.path.join(output, video.key + ".mp4")
 
     print(f"Downloading to -->: {output}")
     report = video.download(quality=quality, path=output, no_title=no_title, return_report=True)


### PR DESCRIPTION
Resolves issue #84.

I add the `output` checking condition to determine whether the output is path or not.

If the output variable is path, using the `video.key` to be the default video file name.

If having any suggestion, please let me know :).

To verify this PR, here are commands I run in the `Python 3.9` Docker container:

```bash
$ docker run -it python:3.9 bash
$ pip install git+https://github.com/peter279k/PHUB.git@issue_84
$ phub -url https://cn.pornhub.com/view_video.php?viewkey=ph5b9a3b6da490f -quality best --use-video-id
```

The expected output is as follows:

```bash
$ phub -url https://cn.pornhub.com/view_video.php?viewkey=ph5b9a3b6da490f -quality best --use-video-id
2026-03-04 18:13:15,040 - BASE API - [BaseCore] - ERROR -
You have chosen to use support HTTP 2.0, but have not installed the dependencies for it.
Please run uv sync --extra httpx, or pip install httpx[http2]

Alternatively, set config.use_http2 = False to disable http2.

2026-03-04 18:13:15,097 - BASE API - [BaseCore] - ERROR -
You have chosen to use support HTTP 2.0, but have not installed the dependencies for it.
Please run uv sync --extra httpx, or pip install httpx[http2]

Alternatively, set config.use_http2 = False to disable http2.

Downloading to -->: ./ph5b9a3b6da490f.mp4
[##################################################] 100.0%Finished :)
```